### PR TITLE
Track non-deterministic transitions for initial states

### DIFF
--- a/tests/pass/non-deterministic_initial_state.rs
+++ b/tests/pass/non-deterministic_initial_state.rs
@@ -1,0 +1,36 @@
+use typestate_proc_macro::typestate;
+
+#[typestate]
+mod m {
+    #[automaton]
+    struct S {}
+
+    #[state]
+    struct A {}
+
+    #[state]
+    struct B {}
+
+    #[state]
+    struct Error {}
+
+    trait A {
+        fn start() -> Fallible;
+        fn next(self) -> B;
+    }
+
+    trait B {
+        fn end(self);
+    }
+
+    trait Error {
+        fn consume(self);
+    }
+
+    enum Fallible {
+        A,
+        Error,
+    }
+}
+
+fn main() {}

--- a/typestate-proc-macro/src/visitors/transition.rs
+++ b/typestate-proc-macro/src/visitors/transition.rs
@@ -123,7 +123,17 @@ impl<'sm> VisitMut for TransitionVisitor<'sm> {
                     );
 
                 self.state_machine_info
-                    .insert_initial(return_ty_ident, fn_ident);
+                    .insert_initial(return_ty_ident.clone(), fn_ident);
+                // mark non det transition as used
+                if self
+                    .state_machine_info
+                    .non_det_transitions
+                    .contains_key(&return_ty_ident)
+                {
+                    self.state_machine_info
+                        .used_non_det_transitions
+                        .insert(return_ty_ident);
+                }
             }
             FnKind::Final => {
                 // add #[must_use]


### PR DESCRIPTION
Properly track non-deterministic transitions when used as initial states. Otherwise, compilation fails with `error: Unused transitions are not allowed.` if such a transition is only used on initial states.

## Example Code

<details>
<summary>Simplified TrafficLight example...</summary>

```rust
use traffic_light::*;
use typestate::typestate;

fn main() {
    let light = TrafficLight::<Red>::turn_on();
    if let Either::Red(red_light) = light {
        let green_light = red_light.to_green();
        let red_light = green_light.to_red();
        red_light.turn_off();
    }
}

#[typestate]
mod traffic_light {
    #[derive(Debug)]
    #[automaton]
    pub struct TrafficLight {}
    #[state]
    pub struct Green;
    #[state]
    pub struct Red;

    pub trait Green {
        fn to_red(self) -> Red;
    }
    pub trait Red {
        fn to_green(self) -> Green;
        fn turn_on() -> Either;
        fn turn_off(self);
    }

    pub enum Either {
        Green,
        Red,
    }
}

impl GreenState for TrafficLight<Green> {
    fn to_red(self) -> TrafficLight<Red> {
        println!("Green -> Red");
        TrafficLight::<Red> {
            state: Red,
        }
    }
}

impl RedState for TrafficLight<Red> {
    fn to_green(self) -> TrafficLight<Green> {
        println!("Red -> Green");
        TrafficLight::<Green> {
            state: Green,
        }
    }

    fn turn_on() -> Either {
        println!("Turning on...");
        Either::Red(TrafficLight::<Red> {
            state: Red,
        })
    }

    fn turn_off(self) {
        println!("Turning off...");
        // ... consume
    }
}
```

</details>

---

Let me know if you need a proper test for these cases.