### PR TITLE
Use more distinctive environment variable names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,9 +213,9 @@
 //! The cargo features you can enable:
 //! - `debug_dot` will generate a `.dot` file of your state machine.
 //!   - This feature can be customized through the following environment variables (taken from the [DOT documentation](https://graphviz.org/doc/info/attrs.html)):
-//!     - `DOT_PAD` - Specifies how much, in inches, to extend the drawing area around the minimal area needed to draw the graph.
-//!     - `DOT_NODESEP` - In `dot`, `nodesep` specifies the minimum space between two adjacent nodes in the same rank, in inches.
-//!     - `DOT_RANKSEP` - In `dot`, sets the desired rank separation, in inches.
+//!     - `TYPESTATE_DOT_PAD` - Specifies how much, in inches, to extend the drawing area around the minimal area needed to draw the graph.
+//!     - `TYPESTATE_DOT_NODESEP` - In `dot`, `nodesep` specifies the minimum space between two adjacent nodes in the same rank, in inches.
+//!     - `TYPESTATE_DOT_RANKSEP` - In `dot`, sets the desired rank separation, in inches.
 //! - `debug_plantuml` will generate a PlantUML state diagram (`.uml` file) of your state machine.
 
 pub extern crate typestate_proc_macro;

--- a/typestate-book/src/features/compilation_flags.md
+++ b/typestate-book/src/features/compilation_flags.md
@@ -24,10 +24,10 @@ typestate = { version = "0.8.0", features = [ "docs-mermaid" ] }
 `export-dot` - will generate a `.dot` file, describing your typestate's state machine.
 You can customize certain `.dot` parameters through the following environment variables:
 
-- `DOT_PAD` - specifies how much, in inches, to extend the drawing area around the minimal area needed to draw the graph.
-- `DOT_NODESEP` - `nodesep` specifies the minimum space between two adjacent nodes in the same rank, in inches.
-- `DOT_RANKSEP` - sets the desired rank separation, in inches.
-- `EXPORT_FOLDER` - declare the target folder for exported files.
+- `TYPESTATE_DOT_PAD` - specifies how much, in inches, to extend the drawing area around the minimal area needed to draw the graph.
+- `TYPESTATE_DOT_NODESEP` - `nodesep` specifies the minimum space between two adjacent nodes in the same rank, in inches.
+- `TYPESTATE_DOT_RANKSEP` - sets the desired rank separation, in inches.
+- `TYPESTATE_EXPORT_FOLDER` - declare the target folder for exported files.
 
 This feature is not activated by default, see below how you can activate it.
 
@@ -56,9 +56,9 @@ These examples are present in the `examples/` folder in the repository's root.
 `export-plantuml` will generate a PlantUML state diagram (`.uml` file) of your state machine.
 Like the previous feature, you can also customize this one through the following environment variables:
 
-- `PLANTUML_NODESEP` - `nodesep` specifies the minimum space between two adjacent nodes in the same rank.
-- `PLANTUML_RANKSEP` - Sets the desired rank separation.
-- `EXPORT_FOLDER` - Declare the target folder for exported files.
+- `TYPESTATE_PLANTUML_NODESEP` - `nodesep` specifies the minimum space between two adjacent nodes in the same rank.
+- `TYPESTATE_PLANTUML_RANKSEP` - Sets the desired rank separation.
+- `TYPESTATE_EXPORT_FOLDER` - Declare the target folder for exported files.
 
 This feature is not activated by default, see below how you can activate it.
 

--- a/typestate-proc-macro/src/igraph/export.rs
+++ b/typestate-proc-macro/src/igraph/export.rs
@@ -183,14 +183,14 @@ pub mod plantuml {
             writeln!(w, "@startuml")?;
             writeln!(w, "hide empty description")?;
 
-            if let Some(s) = ::std::env::var_os("PLANTUML_NODESEP") {
+            if let Some(s) = ::std::env::var_os("TYPESTATE_PLANTUML_NODESEP") {
                 w.write_fmt(format_args!(
                     "skinparam nodesep {}\n",
                     s.into_string().unwrap_or_else(|_| "30".to_string())
                 ))?;
             }
 
-            if let Some(s) = ::std::env::var_os("PLANTUML_RANKSEP") {
+            if let Some(s) = ::std::env::var_os("TYPESTATE_PLANTUML_RANKSEP") {
                 w.write_fmt(format_args!(
                     "skinparam ranksep {}\n",
                     s.into_string().unwrap_or_else(|_| "30".to_string())
@@ -334,9 +334,9 @@ pub mod dot {
 
             w.write_fmt(format_args!(
                 "  graph [pad=\"{}\", nodesep=\"{}\", ranksep=\"{}\"];\n",
-                var_or_default("DOT_PAD", "0.25"),
-                var_or_default("DOT_NODESEP", "0.75"),
-                var_or_default("DOT_RANKSEP", "1"),
+                var_or_default("TYPESTATE_DOT_PAD", "0.25"),
+                var_or_default("TYPESTATE_DOT_NODESEP", "0.75"),
+                var_or_default("TYPESTATE_DOT_RANKSEP", "1"),
             ))?;
 
             writeln!(w, "  _initial_ [{}, shape=circle];", DOT_SPECIAL_NODE)?;
@@ -450,7 +450,7 @@ where
 {
     let folder = {
         let cwd = env::current_dir()?;
-        env::var_os("EXPORT_FOLDER").map_or_else(|| cwd, |dir| Path::new(&dir).to_path_buf())
+        env::var_os("TYPESTATE_EXPORT_FOLDER").map_or_else(|| cwd, |dir| Path::new(&dir).to_path_buf())
     };
     if !folder.exists() {
         create_dir_all(&folder)?;


### PR DESCRIPTION
Just using for example `EXPORT_FOLDER` might easily clash with generic project configuration. So what about prefixing them all?